### PR TITLE
Bugfixes2

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,10 @@ This ensures that users on any supported engine version get an example project t
         * `MSVC v143 - VS 2022 C++ x64/x86 build tools (v14.36-17.6)` - **Required for UE 5.3**
         * `MSVC v143 - VS 2022 C++ x64/x86 build tools (v14.38-17.8)` or newer - **Required for UE 5.4+**
         * `Windows 11 SDK` or `Windows 10 SDK`
+    * **(Optional)** For stricter Clang-based validation (matching Fab's review compiler), also install:
+        * `C++ Clang Compiler for Windows`
+        * `MSBuild support for LLVM (clang-cl) toolset`
+        * Then set `"UseClang": true` in your config's `BuildOptions` section. Note: Clang may not be compatible with older UE versions (5.1-5.3) due to deprecated builtins in engine headers.
 4.  **(Optional) rclone**: For the cloud upload feature, you will need to download [rclone](https://rclone.org/).
 
 ## Quick Start
@@ -135,6 +139,7 @@ Advanced options for controlling the pipeline's behavior.
 
 *   **`FastMode`**: **(Recommended)** If set to `true`, enables a highly optimized build process. It compiles the plugin and example project C++ code together in a single step, drastically reducing build times. If `false`, it uses the original, slower method of compiling the plugin separately before compiling the example project.
 *   **`SkipPluginBuild`**: (Standard Mode Only) If `true`, skips the initial plugin packaging step. Useful for debugging the example project packaging in isolation.
+*   **`UseClang`**: If `true`, uses clang-cl instead of MSVC for compilation. This matches Fab's Clang-based review more closely and catches warnings like `-Wshadow` that MSVC misses. Requires the Clang VS components (see Prerequisites). May not work with UE 5.1-5.3 due to engine header incompatibilities.
 
 ### 2. (Optional) Configure Cloud Uploads
 
@@ -213,7 +218,9 @@ It's a command-line program for managing files on cloud storage. It's a single e
 
 > [!IMPORTANT]
 > **Global Build Configuration (`BuildConfiguration.xml`)**
-> To ensure the correct Visual Studio toolchain is used for each engine version, the `package_fast.ps1` script temporarily modifies the global `BuildConfiguration.xml` file located in `Documents/Unreal Engine/UnrealBuildTool`.
+> To ensure the correct Visual Studio toolchain is used for each engine version, the `package_plugin.ps1` script temporarily modifies the global `BuildConfiguration.xml` file located in `Documents/Unreal Engine/UnrealBuildTool`.
+>
+> The pipeline supports an optional **clang-cl** mode (`"UseClang": true` in config) that uses Clang instead of MSVC for compilation. This can help catch issues that Fab's Clang-based review (Mac and Windows ARM64) would reject, such as `-Wshadow` warnings. However, Clang may not be compatible with older UE versions (5.1-5.3) due to deprecated builtins in engine headers. When `UseClang` is not set, the pipeline uses MSVC with version-pinned toolchains.
 >
 > The script creates a backup and is designed to restore it, even if the build fails. However, if the script is terminated abruptly (e.g., by a system crash or forced shutdown), the backup may not be restored. This could potentially affect other Unreal Engine projects on your system.
 >

--- a/Tools/package_example_project.ps1
+++ b/Tools/package_example_project.ps1
@@ -6,8 +6,8 @@
     (developed in the oldest supported engine version), and for each version in the
     config, it:
     1. Creates a smart copy (excluding .git, build artifacts, etc.)
-    2. Compiles the plugin for the target engine version first (if not excluded).
-    3. Builds the main project C++ to prevent popups.
+    2. Updates the .uplugin engine version.
+    3. Builds the project editor targets (compiles both plugin and project C++ in one step).
     4. Upgrades the project to the target engine version.
     5. Packages C++ and/or Blueprint-only versions directly to the final output directory.
 .NOTES
@@ -137,7 +137,7 @@ foreach ($CurrentEngineVersion in $VersionsToProcess) {
 
         # --- 1. COPY MASTER PROJECT (SMART COPY) ---
         $CurrentStage = "COPY"
-        Write-Host "[1/7] Copying master project..."
+        Write-Host "[1/6] Copying master project..."
         
         $ExcludeDirs = @( ".git", ".vs", ".idea", ".vscode", "Binaries", "Build", "Intermediate", "Saved", "DerivedDataCache", "__pycache__", "Platforms", ".claude" )
         $ExcludeFiles = @( "*.sln", "*.suo", "*.VC.db", "*.DotSettings.user", ".vsconfig", "GEMINI.md", ".gitignore", ".gitmodules" )
@@ -156,7 +156,7 @@ foreach ($CurrentEngineVersion in $VersionsToProcess) {
         # --- 1.5. EXCLUDE OTHER PLUGINS (NEW STEP) ---
         $CurrentStage = "EXCLUDE_PLUGINS"
         if ($Config.ExampleProject.ExcludePluginsFromExample -and $Config.ExampleProject.ExcludePluginsFromExample.Count -gt 0) {
-            Write-Host "[1.5/7] Excluding specified plugins from example project..."
+            Write-Host "[1.5/6] Excluding specified plugins from example project..."
             
             $UProjectJson = Get-Content -Raw -Path $TempUProjectPath | ConvertFrom-Json
             
@@ -185,7 +185,7 @@ foreach ($CurrentEngineVersion in $VersionsToProcess) {
         # --- 1.6. EXCLUDE SPECIFIED FOLDERS (ROBUST) ---
         $CurrentStage = "EXCLUDE_FOLDERS"
         if ($Config.ExampleProject.ExcludeFolders -and $Config.ExampleProject.ExcludeFolders.Count -gt 0) {
-            Write-Host "[1.6/7] Forcefully removing specified folders from example project..."
+            Write-Host "[1.6/6] Forcefully removing specified folders from example project..."
             foreach ($FolderToExclude in $Config.ExampleProject.ExcludeFolders) {
                 $FolderDirToRemove = Join-Path -Path $TempProjectDir -ChildPath $FolderToExclude
                 if (Test-Path $FolderDirToRemove) {
@@ -197,7 +197,7 @@ foreach ($CurrentEngineVersion in $VersionsToProcess) {
         
         # --- 2. UPDATE UPLUGIN FILE VERSION ---
         $CurrentStage = "UPDATE_UPLUGIN"
-        Write-Host "[2/7] Updating .uplugin file version for UE $CurrentEngineVersion..."
+        Write-Host "[2/6] Updating .uplugin file version for UE $CurrentEngineVersion..."
         $PluginUpluginPath = Join-Path -Path $TempProjectDir -ChildPath "Plugins\$($Config.PluginName)\$($Config.PluginName).uplugin"
         if (Test-Path $PluginUpluginPath) {
             $PluginJson = Get-Content -Raw -Path $PluginUpluginPath | ConvertFrom-Json
@@ -208,38 +208,16 @@ foreach ($CurrentEngineVersion in $VersionsToProcess) {
             Write-Host "No .uplugin file found to update." -ForegroundColor Gray
         }
 
-        # --- 3. COMPILE PLUGIN ---
-        $CurrentStage = "COMPILE_PLUGIN"
-        if (-not $Config.ExampleProject.ExcludePlugin) {
-            Write-Host "[3/7] Compiling plugin for UE $CurrentEngineVersion..."
-            
-            $PluginDir = Join-Path -Path $TempProjectDir -ChildPath "Plugins\$($Config.PluginName)"
-            if (-not (Test-Path $PluginUpluginPath)) { throw "Plugin .uplugin file not found at: $PluginUpluginPath" }
-            
-            $RunUATPath = Join-Path -Path $EnginePath -ChildPath "Engine\Build\BatchFiles\RunUAT.bat"
-            & $RunUATPath BuildPlugin -Plugin="$PluginUpluginPath" -Package="$PluginDir\Packages" -TargetPlatforms=Win64 -Rocket | Tee-Object -FilePath $LogFile -Append
-            if ($LASTEXITCODE -ne 0) { throw "Failed to compile plugin for UE $CurrentEngineVersion." }
-        } else {
-            # This condition is now only for the final package, but we still need to compile the plugin for the example to work.
-            Write-Host "[3/7] Compiling plugin for UE $CurrentEngineVersion (required for example project)..."
-            $PluginDir = Join-Path -Path $TempProjectDir -ChildPath "Plugins\$($Config.PluginName)"
-            if (-not (Test-Path $PluginUpluginPath)) { throw "Plugin .uplugin file not found at: $PluginUpluginPath" }
-            
-            $RunUATPath = Join-Path -Path $EnginePath -ChildPath "Engine\Build\BatchFiles\RunUAT.bat"
-            & $RunUATPath BuildPlugin -Plugin="$PluginUpluginPath" -Package="$PluginDir\Packages" -TargetPlatforms=Win64 -Rocket | Tee-Object -FilePath $LogFile -Append
-            if ($LASTEXITCODE -ne 0) { throw "Failed to compile plugin for UE $CurrentEngineVersion." }
-        }
-
-        # --- 4. BUILD PROJECT (to avoid popups) ---
+        # --- 3. BUILD PROJECT & PLUGIN (SINGLE COMPILE STEP) ---
         $CurrentStage = "BUILD_PROJECT"
-        Write-Host "[4/7] Building project editor targets for UE $CurrentEngineVersion..."
+        Write-Host "[3/6] Building project editor targets for UE $CurrentEngineVersion (compiles plugin + project together)..."
         $BuildScriptPath = Join-Path -Path $EnginePath -ChildPath "Engine\Build\BatchFiles\Build.bat"
         & $BuildScriptPath ($MasterProjectName + "Editor") Win64 Development -Project="$TempUProjectPath" | Tee-Object -FilePath $LogFile -Append
         if ($LASTEXITCODE -ne 0) { throw "Failed to build project editor targets for UE $CurrentEngineVersion." }
 
-        # --- 5. UPGRADE PROJECT ---
+        # --- 4. UPGRADE PROJECT ---
         $CurrentStage = "UPGRADE"
-        Write-Host "[5/7] Upgrading project assets for UE $CurrentEngineVersion..."
+        Write-Host "[4/6] Upgrading project assets for UE $CurrentEngineVersion..."
         $UnrealEditorPath = Join-Path -Path $EnginePath -ChildPath "Engine/Binaries/Win64/UnrealEditor-Cmd.exe"
 
         $UProjectJson = Get-Content -Raw -Path $TempUProjectPath | ConvertFrom-Json
@@ -249,10 +227,10 @@ foreach ($CurrentEngineVersion in $VersionsToProcess) {
         & $UnrealEditorPath "$TempUProjectPath" -run=ResavePackages -allowcommandletrendering -autocheckout -projectonly | Tee-Object -FilePath $LogFile -Append
         if ($LASTEXITCODE -ne 0) { throw "Failed to resave/upgrade packages." }
 
-        # --- 6. PACKAGE C++ EXAMPLE (OPTIONAL) ---
+        # --- 5. PACKAGE C++ EXAMPLE (OPTIONAL) ---
         $CurrentStage = "PACKAGE_CPP"
         if ($Config.ExampleProject.GenerateCppExample) {
-            Write-Host "[6/7] Packaging C++ Example..."
+            Write-Host "[5/6] Packaging C++ Example..."
             
             "Binaries", "Intermediate", "Saved", ".vs", "DerivedDataCache" | ForEach-Object {
                 $pathToRemove = Join-Path $TempProjectDir $_
@@ -266,28 +244,17 @@ foreach ($CurrentEngineVersion in $VersionsToProcess) {
                 if (Test-Path $PluginDirToRemove) { Remove-Item -Path $PluginDirToRemove -Recurse -Force }
             }
 
-            # --- Exclude custom folders for CPP packaging ---
-            if ($Config.ExampleProject.ExcludeFolders) {
-                foreach ($Folder in $Config.ExampleProject.ExcludeFolders) {
-                    $PathToRemove = Join-Path -Path $TempProjectDir -ChildPath $Folder
-                    if (Test-Path $PathToRemove) {
-                        Write-Host "Excluding folder for C++ package: $PathToRemove"
-                        Remove-Item -Recurse -Force -Path $PathToRemove
-                    }
-                }
-            }
-            
             $FinalZipPath = Join-Path -Path $FinalOutputDir -ChildPath "$($MasterProjectName)_v$($ProjectVersion)_CPP_UE$($CurrentEngineVersion).zip"
             Compress-Archive -Path "$TempProjectDir\*" -DestinationPath $FinalZipPath -Force
             Write-Host "C++ example created at: $FinalZipPath" -ForegroundColor Green
         } else {
-             Write-Host "[6/7] Skipping C++ example packaging." -ForegroundColor Gray
+             Write-Host "[5/6] Skipping C++ example packaging." -ForegroundColor Gray
         }
 
-        # --- 7. PACKAGE BLUEPRINT EXAMPLE (OPTIONAL) ---
+        # --- 6. PACKAGE BLUEPRINT EXAMPLE (OPTIONAL) ---
         $CurrentStage = "PACKAGE_BP"
         if ($Config.ExampleProject.GenerateBlueprintExample) {
-            Write-Host "[7/7] Creating and packaging Blueprint-only example..."
+            Write-Host "[6/6] Creating and packaging Blueprint-only example..."
             
             "Binaries", "Intermediate", "Saved", ".vs", "DerivedDataCache", "Source" | ForEach-Object {
                 $pathToRemove = Join-Path $TempProjectDir $_ 
@@ -313,17 +280,6 @@ foreach ($CurrentEngineVersion in $VersionsToProcess) {
                 }
             }
             
-            # --- Exclude custom folders for BP packaging ---
-            if ($Config.ExampleProject.ExcludeFolders) {
-                foreach ($Folder in $Config.ExampleProject.ExcludeFolders) {
-                    $PathToRemove = Join-Path -Path $TempProjectDir -ChildPath $Folder
-                    if (Test-Path $PathToRemove) {
-                        Write-Host "Excluding folder for Blueprint package: $PathToRemove"
-                        Remove-Item -Recurse -Force -Path $PathToRemove
-                    }
-                }
-            }
-
             if ($Config.ExampleProject.BlueprintOnlyExcludeFolders) {
                 foreach ($ExcludeFolder in $Config.ExampleProject.BlueprintOnlyExcludeFolders) {
                     $FolderToRemove = Join-Path -Path $TempProjectDir -ChildPath $ExcludeFolder
@@ -335,7 +291,7 @@ foreach ($CurrentEngineVersion in $VersionsToProcess) {
             Compress-Archive -Path "$TempProjectDir\*" -DestinationPath $FinalZipPath -Force
             Write-Host "Blueprint example created at: $FinalZipPath" -ForegroundColor Green
         } else {
-            Write-Host "[7/7] Skipping Blueprint example packaging." -ForegroundColor Gray
+            Write-Host "[6/6] Skipping Blueprint example packaging." -ForegroundColor Gray
         }
 
     } catch {

--- a/Tools/package_example_project.ps1
+++ b/Tools/package_example_project.ps1
@@ -118,19 +118,27 @@ foreach ($CurrentEngineVersion in $VersionsToProcess) {
         }
         
         $ToolchainVersion = switch ($CurrentEngineVersion) {
-            "5.1" { "14.32.31326" } 
-            "5.2" { "14.34.31933" } 
-            "5.3" { "14.36.32532" } 
-            "5.4" { "14.38.33130" } 
-            "5.5" { "14.38.33130" } 
-            "5.6" { "14.38.33130" } 
+            "5.1" { "14.32.31326" }
+            "5.2" { "14.34.31933" }
+            "5.3" { "14.36.32532" }
+            "5.4" { "14.38.33130" }
+            "5.5" { "14.38.33130" }
+            "5.6" { "14.38.33130" }
             default { "Latest" }
         }
+
+        $CompilerXml = ""
+        if ($Config.BuildOptions -and $Config.BuildOptions.PSObject.Properties.Name -contains 'UseClang' -and $Config.BuildOptions.UseClang) {
+            $CompilerXml = "        <Compiler>Clang</Compiler>"
+        } else {
+            $CompilerXml = "        <CompilerVersion>$($ToolchainVersion)</CompilerVersion>"
+        }
+
         @"
 <?xml version="1.0" encoding="utf-8" ?>
 <Configuration xmlns="https://www.unrealengine.com/BuildConfiguration">
     <WindowsPlatform>
-        <CompilerVersion>$($ToolchainVersion)</CompilerVersion>
+$CompilerXml
     </WindowsPlatform>
 </Configuration>
 "@ | Out-File -FilePath $UserBuildConfigPath -Encoding utf8

--- a/Tools/package_fast_combined.ps1
+++ b/Tools/package_fast_combined.ps1
@@ -130,19 +130,27 @@ foreach ($CurrentEngineVersion in $VersionsToProcess) {
         }
         
         $ToolchainVersion = switch ($CurrentEngineVersion) {
-            "5.1" { "14.32.31326" } 
-            "5.2" { "14.34.31933" } 
-            "5.3" { "14.36.32532" } 
-            "5.4" { "14.38.33130" } 
-            "5.5" { "14.38.33130" } 
-            "5.6" { "14.38.33130" } 
+            "5.1" { "14.32.31326" }
+            "5.2" { "14.34.31933" }
+            "5.3" { "14.36.32532" }
+            "5.4" { "14.38.33130" }
+            "5.5" { "14.38.33130" }
+            "5.6" { "14.38.33130" }
             default { "Latest" }
         }
+
+        $CompilerXml = ""
+        if ($Config.BuildOptions -and $Config.BuildOptions.PSObject.Properties.Name -contains 'UseClang' -and $Config.BuildOptions.UseClang) {
+            $CompilerXml = "        <Compiler>Clang</Compiler>"
+        } else {
+            $CompilerXml = "        <CompilerVersion>$($ToolchainVersion)</CompilerVersion>"
+        }
+
         @"
 <?xml version="1.0" encoding="utf-8" ?>
 <Configuration xmlns="https://www.unrealengine.com/BuildConfiguration">
     <WindowsPlatform>
-        <CompilerVersion>$($ToolchainVersion)</CompilerVersion>
+$CompilerXml
     </WindowsPlatform>
 </Configuration>
 "@ | Out-File -FilePath $UserBuildConfigPath -Encoding utf8

--- a/Tools/package_plugin.ps1
+++ b/Tools/package_plugin.ps1
@@ -136,15 +136,24 @@ foreach ($CurrentEngineVersion in $VersionsToProcess) {
             "5.2" { "14.34.31933" } # VS 2022 v17.4
             "5.3" { "14.36.32532" } # VS 2022 v17.6
             "5.4" { "14.38.33130" } # VS 2022 v17.8
-            "5.5" { "14.38.33130" } # VS 2022 v17.10  
+            "5.5" { "14.38.33130" } # VS 2022 v17.10
             "5.6" { "14.38.33130" } # VS 2022 v17.10 or later #14.40.33807
             default { "Latest" }
         }
+
+        # Build the compiler configuration XML
+        $CompilerXml = ""
+        if ($Config.BuildOptions -and $Config.BuildOptions.PSObject.Properties.Name -contains 'UseClang' -and $Config.BuildOptions.UseClang) {
+            $CompilerXml = "        <Compiler>Clang</Compiler>"
+        } else {
+            $CompilerXml = "        <CompilerVersion>$($ToolchainVersion)</CompilerVersion>"
+        }
+
         @"
 <?xml version="1.0" encoding="utf-8" ?>
 <Configuration xmlns="https://www.unrealengine.com/BuildConfiguration">
     <WindowsPlatform>
-        <CompilerVersion>$($ToolchainVersion)</CompilerVersion>
+$CompilerXml
     </WindowsPlatform>
 </Configuration>
 "@ | Out-File -FilePath $UserBuildConfigPath -Encoding utf8

--- a/run_pipeline.ps1
+++ b/run_pipeline.ps1
@@ -144,7 +144,7 @@ try {
                 Write-Host "`n[TASK 1/3] Skipping plugin packaging for $EngineVersion (SkipPluginBuild is true in config)." -ForegroundColor Yellow
             } else {
                 Write-Host "`n[TASK 1/3] Running plugin packaging script for $EngineVersion..." -ForegroundColor Cyan
-                & "$ScriptDir/Tools/package_fast.ps1" -OutputDirectory $FinalOutputDir -EngineVersion $EngineVersion -UseCache:$UseCache -ConfigPath $ConfigPath
+                & "$ScriptDir/Tools/package_plugin.ps1" -OutputDirectory $FinalOutputDir -EngineVersion $EngineVersion -UseCache:$UseCache -ConfigPath $ConfigPath
                 if ($LASTEXITCODE -ne 0) { throw "Plugin packaging failed for $EngineVersion." }
             }
 


### PR DESCRIPTION
This pull request introduces support for using the Clang compiler (`clang-cl`) as an alternative to MSVC for Unreal Engine plugin and project builds, aligning the build process more closely with Fab's Clang-based review environment. It adds configuration options, updates documentation, and refactors the packaging scripts to support this feature. Additionally, the `package_fast.ps1` script has been renamed to `package_plugin.ps1`, and the example project packaging process has been streamlined.

**Clang Compiler Support & Build Configuration:**

* Added a `UseClang` option to the build configuration, allowing users to select Clang (`clang-cl`) as the compiler. The scripts now generate the appropriate XML for Unreal's `BuildConfiguration.xml`, setting either `<Compiler>Clang</Compiler>` or `<CompilerVersion>...` as needed. This is supported in `package_plugin.ps1`, `package_example_project.ps1`, and `package_fast_combined.ps1`. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R56-R59) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R142) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L216-R223) [[4]](diffhunk://#diff-78c407013bf20f6fa22c14f08f4e2eb207517a11ee400f6e2f894198f51a34b0R141-R153) [[5]](diffhunk://#diff-498b8bb15e564959e80ee622c5644f4166b5901c996d35be65b417a74a7c64a9R129-R148) [[6]](diffhunk://#diff-099516d481f138cbab256fcad590aaa9929fb04708e36dd7c3f587d621bffec8R143-R156)
* Updated the documentation (`README.md`) to explain the new Clang option, its prerequisites, and compatibility notes (not recommended for UE 5.1–5.3 due to engine header issues). [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R56-R59) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R142) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L216-R223)

**Script Refactoring & Renaming:**

* Renamed `package_fast.ps1` to `package_plugin.ps1` for clarity and updated all references accordingly, including in `run_pipeline.ps1`.
* Updated the documentation and script comments to reflect this renaming.

**Example Project Packaging Process Improvements:**

* Simplified the example project packaging process in `package_example_project.ps1` by removing the separate plugin compilation step. Now, the plugin and project C++ are built together in a single step, aligning with the "fast mode" approach. Progress messages and step counts have been updated for clarity. [[1]](diffhunk://#diff-498b8bb15e564959e80ee622c5644f4166b5901c996d35be65b417a74a7c64a9L9-R10) [[2]](diffhunk://#diff-498b8bb15e564959e80ee622c5644f4166b5901c996d35be65b417a74a7c64a9R129-R148) [[3]](diffhunk://#diff-498b8bb15e564959e80ee622c5644f4166b5901c996d35be65b417a74a7c64a9L159-R167) [[4]](diffhunk://#diff-498b8bb15e564959e80ee622c5644f4166b5901c996d35be65b417a74a7c64a9L188-R196) [[5]](diffhunk://#diff-498b8bb15e564959e80ee622c5644f4166b5901c996d35be65b417a74a7c64a9L211-R228) [[6]](diffhunk://#diff-498b8bb15e564959e80ee622c5644f4166b5901c996d35be65b417a74a7c64a9L252-R241) [[7]](diffhunk://#diff-498b8bb15e564959e80ee622c5644f4166b5901c996d35be65b417a74a7c64a9L269-R265) [[8]](diffhunk://#diff-498b8bb15e564959e80ee622c5644f4166b5901c996d35be65b417a74a7c64a9L316-L326) [[9]](diffhunk://#diff-498b8bb15e564959e80ee622c5644f4166b5901c996d35be65b417a74a7c64a9L338-R302)

These changes make the build pipeline more flexible and robust, enabling stricter validation and faster builds while improving maintainability and documentation.